### PR TITLE
feat: Add f2py through NumPy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN cp /root/.profile ${HOME}/.profile && \
     echo 'export PATH=${HOME}/.local/bin:$PATH' >> ${HOME}/.bashrc && \
     echo 'export PATH=/usr/local/MG5_aMC_v2_7_0_py3/bin:$PATH' >> ${HOME}/.bashrc && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir six
+    python -m pip install --no-cache-dir six numpy
 
 #ENV USER docker
 #USER docker


### PR DESCRIPTION
`f2py` is needed to wrap FORTAN in Python that is used in some techniques, and is [now part of NumPy](https://numpy.org/doc/stable/f2py/).

c.f. https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/FAQ-General-4#Pythton

```
* Install NumPy to also install f2py
   - c.f. https://numpy.org/doc/stable/f2py/
   - f2py is needed to wrap FORTRAN in some cases
```